### PR TITLE
fix: typo in fps update loss with current loss amount

### DIFF
--- a/src/frankencoin.ts
+++ b/src/frankencoin.ts
@@ -60,7 +60,7 @@ ponder.on('Frankencoin:Loss', async ({ event, context }) => {
 			reserve: 0n,
 		},
 		update: ({ current }) => ({
-			loss: current.profits + event.args.amount,
+			loss: current.loss + event.args.amount,
 		}),
 	});
 


### PR DESCRIPTION
https://github.com/Frankencoin-ZCHF/frankencoin-dapp/issues/133

should solve the loss counter. no testing, however, quite obvious.

![Screenshot 2024-11-11 at 9 50 08 AM](https://github.com/user-attachments/assets/5566eff6-f355-4e0f-a2ae-be7545d77f1e)
