### PR TITLE
fix: correct ERC20TotalSupply day bucketing (seconds vs milliseconds)

### DIFF
--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -29,6 +29,6 @@ export function timestampToSeconds(ms: number | string) {
 	return String(Math.floor(Number(ms) / 1000));
 }
 
-export function timestampStartOfDay(ms: number | string) {
-	return String(Number(ms) - (Number(ms) % 86_400_000));
+export function timestampStartOfDay(seconds: number | string) {
+	return String(Number(seconds) - (Number(seconds) % 86_400));
 }


### PR DESCRIPTION
## Summary

- `timestampStartOfDay` was using `86_400_000` (milliseconds per day) as the modulo divisor, but was called with `event.block.timestamp` which is in **seconds**
- This caused all `ERC20TotalSupply` entries to bucket into ~1000-day intervals (exactly day 19,000 and 20,000 of the Unix epoch: `1641600000` and `1728000000`) instead of per day
- Result: Ethereum mainnet only had 2 rows in `eRC20TotalSupplys`, and the API accumulated a massive supply spike (+229%) at `1728000000` when all L2 chains were merged in simultaneously, followed by a crash the next day

## Fix

Changed divisor from `86_400_000` to `86_400` so the function correctly rounds block timestamps (seconds) to the start of the current day.

## Test plan

- [ ] Trigger a Ponder re-index and verify `eRC20TotalSupplys` now produces one row per day per chain
- [ ] Confirm the API supply curve no longer shows spikes at `1641600000` / `1728000000`
- [ ] Verify `TransactionLog.ts` is unaffected (uses inline BigInt arithmetic, not this function)

🤖 Generated with [Claude Code](https://claude.com/claude-code)