### PR TITLE
fix: backfill same-block events for factory positions on PostgreSQL

### DIFF
--- a/src/MintingHubV1.ts
+++ b/src/MintingHubV1.ts
@@ -4,11 +4,14 @@ import {
 	CommonEcosystem,
 	MintingHubV1ChallengeBidV1,
 	MintingHubV1ChallengeV1,
+	MintingHubV1MintingUpdateV1,
+	MintingHubV1OwnerTransfersV1,
 	MintingHubV1PositionV1,
 	MintingHubV1Status,
 } from 'ponder:schema';
-import { Address } from 'viem';
+import { Address, decodeAbiParameters } from 'viem';
 import { normalizeAddress } from './utils/format';
+import { MINTING_UPDATE_TOPIC_V1, OWNERSHIP_TRANSFERRED_TOPIC } from './utils/ownership';
 
 /*
 Events
@@ -141,6 +144,103 @@ ponder.on('MintingHubV1:PositionOpened', async ({ event, context }) => {
 		availableForClones,
 		minted,
 	});
+
+	// ------------------------------------------------------------------
+	// POSTGRES BACKFILL
+	if (process.env.DATABASE_URL) {
+		const receipt = await client.getTransactionReceipt({ hash: event.transaction.hash });
+		const positionNorm = normalizeAddress(position);
+		let ownerCount = 0n;
+		let mintCount = 0n;
+		let prevSize: bigint | undefined;
+		let prevPrice: bigint | undefined;
+		let prevMinted: bigint | undefined;
+
+		const OneMonth = 60 * 60 * 24 * 30;
+		const OneYear = 60 * 60 * 24 * 365;
+		const secToExp = Math.floor(Number(expiration) - Number(event.block.timestamp));
+		const feeTimeframe = Math.max(OneMonth, secToExp);
+		const feePPM = BigInt(Math.floor((feeTimeframe * annualInterestPPM) / OneYear));
+
+		for (const log of receipt.logs) {
+			if (normalizeAddress(log.address) !== positionNorm) continue;
+			const topic = log.topics[0];
+
+			if (topic === OWNERSHIP_TRANSFERRED_TOPIC) {
+				const t1 = log.topics[1];
+				const t2 = log.topics[2];
+				if (!t1 || !t2) continue;
+				ownerCount++;
+				await context.db
+					.insert(MintingHubV1OwnerTransfersV1)
+					.values({
+						version: 1,
+						position: positionNorm,
+						count: ownerCount,
+						created: event.block.timestamp,
+						previousOwner: normalizeAddress('0x' + t1.slice(26)),
+						newOwner: normalizeAddress('0x' + t2.slice(26)),
+						txHash: event.transaction.hash,
+					})
+					.onConflictDoNothing();
+			} else if (topic === MINTING_UPDATE_TOPIC_V1) {
+				const [size, logPrice, mintedAmt] = decodeAbiParameters(
+					[{ type: 'uint256' }, { type: 'uint256' }, { type: 'uint256' }, { type: 'uint256' }],
+					log.data
+				);
+				mintCount++;
+				const sizeAdjusted = prevSize !== undefined ? size - prevSize : size;
+				const priceAdjusted = prevPrice !== undefined ? logPrice - prevPrice : logPrice;
+				const mintedAdjusted = prevMinted !== undefined ? mintedAmt - prevMinted : mintedAmt;
+				await context.db
+					.insert(MintingHubV1MintingUpdateV1)
+					.values({
+						count: mintCount,
+						txHash: event.transaction.hash,
+						created: event.block.timestamp,
+						position: positionNorm,
+						owner: normalizeAddress(owner),
+						isClone,
+						collateral: normalizeAddress(collateral),
+						collateralName,
+						collateralSymbol,
+						collateralDecimals,
+						size,
+						price: logPrice,
+						minted: mintedAmt,
+						sizeAdjusted,
+						priceAdjusted,
+						mintedAdjusted,
+						annualInterestPPM,
+						reserveContribution,
+						feeTimeframe,
+						feePPM: parseInt(feePPM.toString()),
+						feePaid: mintedAdjusted > 0n ? (feePPM * mintedAdjusted) / 1_000_000n : 0n,
+					})
+					.onConflictDoNothing();
+				prevSize = size;
+				prevPrice = logPrice;
+				prevMinted = mintedAmt;
+			}
+		}
+
+		if (ownerCount > 0n || mintCount > 0n) {
+			await context.db
+				.insert(MintingHubV1Status)
+				.values({
+					position: positionNorm,
+					ownerTransfersCounter: ownerCount,
+					mintingUpdatesCounter: mintCount,
+					challengeStartedCounter: 0n,
+					challengeAvertedBidsCounter: 0n,
+					challengeSucceededBidsCounter: 0n,
+				})
+				.onConflictDoUpdate((current) => ({
+					ownerTransfersCounter: current.ownerTransfersCounter > ownerCount ? current.ownerTransfersCounter : ownerCount,
+					mintingUpdatesCounter: current.mintingUpdatesCounter > mintCount ? current.mintingUpdatesCounter : mintCount,
+				}));
+		}
+	}
 
 	// ------------------------------------------------------------------
 	// COMMON

--- a/src/MintingHubV2.ts
+++ b/src/MintingHubV2.ts
@@ -1,17 +1,50 @@
-import { ERC20ABI } from '@frankencoin/zchf';
-import { ponder } from 'ponder:registry';
+import { ADDRESS, ERC20ABI } from '@frankencoin/zchf';
+import { Context, ponder } from 'ponder:registry';
 import {
 	CommonEcosystem,
 	MintingHubV2ChallengeBidV2,
 	MintingHubV2ChallengeV2,
-	MintingHubV2OwnerTransfersV2,
 	MintingHubV2PositionV2,
 	MintingHubV2Status,
 } from 'ponder:schema';
 import { normalizeAddress } from './utils/format';
+import { Address } from 'viem';
+import { mainnet } from 'viem/chains';
 
+const CLONE_HELPER = normalizeAddress(ADDRESS[mainnet.id].cloneHelper);
 // keccak256("OwnershipTransferred(address,address)")
-const OWNERSHIP_TRANSFERRED_TOPIC = '0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0';
+const OWNERSHIP_TRANSFERRED_TOPIC = '0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0' as const;
+
+/**
+ * If a MintingUpdate originates from a CloneHelper tx, the position's owner in the DB is still
+ * the CloneHelper (the 0x0→CloneHelper OwnershipTransferred log was already processed, but the
+ * CloneHelper→beneficiary transfer log comes later in the same tx).
+ * We fetch the receipt and find that second transfer to recover the actual beneficiary.
+ */
+async function resolvePositionOwner(
+	owner: Address,
+	positionAddress: Address,
+	txHash: `0x${string}`,
+	client: Context['client']
+): Promise<Address> {
+	if (owner !== CLONE_HELPER) return owner;
+
+	const receipt = await client.getTransactionReceipt({ hash: txHash });
+
+	for (const log of receipt.logs) {
+		if (
+			normalizeAddress(log.address) === positionAddress &&
+			log.topics[0] === OWNERSHIP_TRANSFERRED_TOPIC &&
+			log.topics[1] !== undefined &&
+			log.topics[2] !== undefined &&
+			normalizeAddress(('0x' + log.topics[1].slice(26)) as Address) === CLONE_HELPER
+		) {
+			return normalizeAddress(('0x' + log.topics[2].slice(26)) as Address);
+		}
+	}
+
+	return owner;
+}
 
 /*
 Events
@@ -116,9 +149,18 @@ ponder.on('MintingHubV2:PositionOpened', async ({ event, context }) => {
 	// ------------------------------------------------------------------
 	// ------------------------------------------------------------------
 	// Create position entry for DB
+	// When a position is opened via CloneHelper, event.args.owner is still the
+	// CloneHelper address. Resolve to the actual beneficiary before storing.
+	const resolvedOwner = await resolvePositionOwner(
+		normalizeAddress(owner),
+		normalizeAddress(position),
+		event.transaction.hash,
+		client
+	);
+
 	await context.db.insert(MintingHubV2PositionV2).values({
 		position: normalizeAddress(position),
-		owner,
+		owner: resolvedOwner,
 		zchf,
 		collateral,
 		price,
@@ -154,74 +196,6 @@ ponder.on('MintingHubV2:PositionOpened', async ({ event, context }) => {
 		availableForMinting,
 		minted,
 	});
-
-	// ------------------------------------------------------------------
-	// BACKFILL ATOMIC OWNERSHIP TRANSFERS
-	//
-	// `ponder start` (production) only begins watching a factory-discovered
-	// address after the PositionOpened log fires. Any OwnershipTransferred
-	// logs in the same transaction are therefore invisible to the
-	// PositionV2:OwnershipTransferred handler. We scan the full receipt here
-	// and insert every transfer atomically; the last one sets the owner.
-	{
-		const receipt = await client.getTransactionReceipt({ hash: event.transaction.hash });
-		const positionNorm = normalizeAddress(position);
-
-		let count = 0n;
-		let finalOwnerTopic: string | undefined;
-
-		for (const log of receipt.logs) {
-			const t1 = log.topics[1];
-			const t2 = log.topics[2];
-			if (
-				normalizeAddress(log.address) !== positionNorm ||
-				log.topics[0] !== OWNERSHIP_TRANSFERRED_TOPIC ||
-				!t1 ||
-				!t2
-			)
-				continue;
-
-			count++;
-			finalOwnerTopic = t2;
-
-			await context.db
-				.insert(MintingHubV2OwnerTransfersV2)
-				.values({
-					version: 2,
-					position: positionNorm,
-					count,
-					created: event.block.timestamp,
-					previousOwner: normalizeAddress('0x' + t1.slice(26)),
-					newOwner: normalizeAddress('0x' + t2.slice(26)),
-					txHash: event.transaction.hash,
-				})
-				.onConflictDoNothing();
-		}
-
-		if (count > 0n && finalOwnerTopic) {
-			const n = count;
-			// Upsert counter; take the max so dev-mode runs (where
-			// PositionV2:OwnershipTransferred already incremented it) are safe.
-			await context.db
-				.insert(MintingHubV2Status)
-				.values({
-					position: positionNorm,
-					ownerTransfersCounter: n,
-					mintingUpdatesCounter: 0n,
-					challengeStartedCounter: 0n,
-					challengeAvertedBidsCounter: 0n,
-					challengeSucceededBidsCounter: 0n,
-				})
-				.onConflictDoUpdate((current) => ({
-					ownerTransfersCounter: current.ownerTransfersCounter > n ? current.ownerTransfersCounter : n,
-				}));
-
-			// Correct the owner to the actual final recipient.
-			await context.db
-				.update(MintingHubV2PositionV2, { position: positionNorm })
-				.set({ owner: normalizeAddress('0x' + finalOwnerTopic.slice(26)) });
-		}
-	}
 
 	// ------------------------------------------------------------------
 	// COMMON

--- a/src/MintingHubV2.ts
+++ b/src/MintingHubV2.ts
@@ -156,14 +156,13 @@ ponder.on('MintingHubV2:PositionOpened', async ({ event, context }) => {
 	});
 
 	// ------------------------------------------------------------------
-	// BACKFILL PRE-DISCOVERY OWNERSHIP TRANSFERS
+	// BACKFILL ATOMIC OWNERSHIP TRANSFERS
 	//
 	// `ponder start` (production) only begins watching a factory-discovered
 	// address after the PositionOpened log fires. Any OwnershipTransferred
-	// logs that appear earlier in the same transaction are therefore invisible
-	// to the PositionV2:OwnershipTransferred handler.  We scan the receipt
-	// here and insert those records ourselves so the data is consistent
-	// between `ponder dev` and `ponder start`.
+	// logs in the same transaction are therefore invisible to the
+	// PositionV2:OwnershipTransferred handler. We scan the full receipt here
+	// and insert every transfer atomically; the last one sets the owner.
 	{
 		const receipt = await client.getTransactionReceipt({ hash: event.transaction.hash });
 		const positionNorm = normalizeAddress(position);
@@ -177,8 +176,6 @@ ponder.on('MintingHubV2:PositionOpened', async ({ event, context }) => {
 			if (
 				normalizeAddress(log.address) !== positionNorm ||
 				log.topics[0] !== OWNERSHIP_TRANSFERRED_TOPIC ||
-				log.logIndex == null ||
-				log.logIndex >= event.log.logIndex ||
 				!t1 ||
 				!t2
 			)

--- a/src/MintingHubV2.ts
+++ b/src/MintingHubV2.ts
@@ -4,10 +4,14 @@ import {
 	CommonEcosystem,
 	MintingHubV2ChallengeBidV2,
 	MintingHubV2ChallengeV2,
+	MintingHubV2OwnerTransfersV2,
 	MintingHubV2PositionV2,
 	MintingHubV2Status,
 } from 'ponder:schema';
 import { normalizeAddress } from './utils/format';
+
+// keccak256("OwnershipTransferred(address,address)")
+const OWNERSHIP_TRANSFERRED_TOPIC = '0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0';
 
 /*
 Events
@@ -150,6 +154,77 @@ ponder.on('MintingHubV2:PositionOpened', async ({ event, context }) => {
 		availableForMinting,
 		minted,
 	});
+
+	// ------------------------------------------------------------------
+	// BACKFILL PRE-DISCOVERY OWNERSHIP TRANSFERS
+	//
+	// `ponder start` (production) only begins watching a factory-discovered
+	// address after the PositionOpened log fires. Any OwnershipTransferred
+	// logs that appear earlier in the same transaction are therefore invisible
+	// to the PositionV2:OwnershipTransferred handler.  We scan the receipt
+	// here and insert those records ourselves so the data is consistent
+	// between `ponder dev` and `ponder start`.
+	{
+		const receipt = await client.getTransactionReceipt({ hash: event.transaction.hash });
+		const positionNorm = normalizeAddress(position);
+
+		let count = 0n;
+		let finalOwnerTopic: string | undefined;
+
+		for (const log of receipt.logs) {
+			const t1 = log.topics[1];
+			const t2 = log.topics[2];
+			if (
+				normalizeAddress(log.address) !== positionNorm ||
+				log.topics[0] !== OWNERSHIP_TRANSFERRED_TOPIC ||
+				log.logIndex == null ||
+				log.logIndex >= event.log.logIndex ||
+				!t1 ||
+				!t2
+			)
+				continue;
+
+			count++;
+			finalOwnerTopic = t2;
+
+			await context.db
+				.insert(MintingHubV2OwnerTransfersV2)
+				.values({
+					version: 2,
+					position: positionNorm,
+					count,
+					created: event.block.timestamp,
+					previousOwner: normalizeAddress('0x' + t1.slice(26)),
+					newOwner: normalizeAddress('0x' + t2.slice(26)),
+					txHash: event.transaction.hash,
+				})
+				.onConflictDoNothing();
+		}
+
+		if (count > 0n && finalOwnerTopic) {
+			const n = count;
+			// Upsert counter; take the max so dev-mode runs (where
+			// PositionV2:OwnershipTransferred already incremented it) are safe.
+			await context.db
+				.insert(MintingHubV2Status)
+				.values({
+					position: positionNorm,
+					ownerTransfersCounter: n,
+					mintingUpdatesCounter: 0n,
+					challengeStartedCounter: 0n,
+					challengeAvertedBidsCounter: 0n,
+					challengeSucceededBidsCounter: 0n,
+				})
+				.onConflictDoUpdate((current) => ({
+					ownerTransfersCounter: current.ownerTransfersCounter > n ? current.ownerTransfersCounter : n,
+				}));
+
+			// Correct the owner to the actual final recipient.
+			await context.db
+				.update(MintingHubV2PositionV2, { position: positionNorm })
+				.set({ owner: normalizeAddress('0x' + finalOwnerTopic.slice(26)) });
+		}
+	}
 
 	// ------------------------------------------------------------------
 	// COMMON

--- a/src/MintingHubV2.ts
+++ b/src/MintingHubV2.ts
@@ -1,5 +1,5 @@
-import { ADDRESS, ERC20ABI } from '@frankencoin/zchf';
-import { Context, ponder } from 'ponder:registry';
+import { ERC20ABI } from '@frankencoin/zchf';
+import { ponder } from 'ponder:registry';
 import {
 	CommonEcosystem,
 	MintingHubV2ChallengeBidV2,
@@ -8,43 +8,7 @@ import {
 	MintingHubV2Status,
 } from 'ponder:schema';
 import { normalizeAddress } from './utils/format';
-import { Address } from 'viem';
-import { mainnet } from 'viem/chains';
-
-const CLONE_HELPER = normalizeAddress(ADDRESS[mainnet.id].cloneHelper);
-// keccak256("OwnershipTransferred(address,address)")
-const OWNERSHIP_TRANSFERRED_TOPIC = '0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0' as const;
-
-/**
- * If a MintingUpdate originates from a CloneHelper tx, the position's owner in the DB is still
- * the CloneHelper (the 0x0→CloneHelper OwnershipTransferred log was already processed, but the
- * CloneHelper→beneficiary transfer log comes later in the same tx).
- * We fetch the receipt and find that second transfer to recover the actual beneficiary.
- */
-async function resolvePositionOwner(
-	owner: Address,
-	positionAddress: Address,
-	txHash: `0x${string}`,
-	client: Context['client']
-): Promise<Address> {
-	if (owner !== CLONE_HELPER) return owner;
-
-	const receipt = await client.getTransactionReceipt({ hash: txHash });
-
-	for (const log of receipt.logs) {
-		if (
-			normalizeAddress(log.address) === positionAddress &&
-			log.topics[0] === OWNERSHIP_TRANSFERRED_TOPIC &&
-			log.topics[1] !== undefined &&
-			log.topics[2] !== undefined &&
-			normalizeAddress(('0x' + log.topics[1].slice(26)) as Address) === CLONE_HELPER
-		) {
-			return normalizeAddress(('0x' + log.topics[2].slice(26)) as Address);
-		}
-	}
-
-	return owner;
-}
+import { resolvePositionOwner } from './utils/ownership';
 
 /*
 Events
@@ -151,12 +115,7 @@ ponder.on('MintingHubV2:PositionOpened', async ({ event, context }) => {
 	// Create position entry for DB
 	// When a position is opened via CloneHelper, event.args.owner is still the
 	// CloneHelper address. Resolve to the actual beneficiary before storing.
-	const resolvedOwner = await resolvePositionOwner(
-		normalizeAddress(owner),
-		normalizeAddress(position),
-		event.transaction.hash,
-		client
-	);
+	const resolvedOwner = await resolvePositionOwner(normalizeAddress(owner), normalizeAddress(position), event.transaction.hash, client);
 
 	await context.db.insert(MintingHubV2PositionV2).values({
 		position: normalizeAddress(position),

--- a/src/MintingHubV2.ts
+++ b/src/MintingHubV2.ts
@@ -1,14 +1,18 @@
-import { ERC20ABI } from '@frankencoin/zchf';
+import { ADDRESS, ERC20ABI, SavingsV2ABI } from '@frankencoin/zchf';
 import { ponder } from 'ponder:registry';
 import {
 	CommonEcosystem,
 	MintingHubV2ChallengeBidV2,
 	MintingHubV2ChallengeV2,
+	MintingHubV2MintingUpdateV2,
+	MintingHubV2OwnerTransfersV2,
 	MintingHubV2PositionV2,
 	MintingHubV2Status,
 } from 'ponder:schema';
+import { decodeAbiParameters } from 'viem';
+import { mainnet } from 'viem/chains';
 import { normalizeAddress } from './utils/format';
-import { resolvePositionOwner } from './utils/ownership';
+import { MINTING_UPDATE_TOPIC_V2, OWNERSHIP_TRANSFERRED_TOPIC, resolvePositionOwner } from './utils/ownership';
 
 /*
 Events
@@ -155,6 +159,116 @@ ponder.on('MintingHubV2:PositionOpened', async ({ event, context }) => {
 		availableForMinting,
 		minted,
 	});
+
+	// ------------------------------------------------------------------
+	// POSTGRES BACKFILL
+	// PostgreSQL-backed Ponder misses all events in the same block as a
+	// factory-discovery event (PositionOpened). Scan the receipt and insert
+	// OwnershipTransferred + MintingUpdate records that would otherwise be lost.
+	if (process.env.DATABASE_URL) {
+		const receipt = await client.getTransactionReceipt({ hash: event.transaction.hash });
+		const positionNorm = normalizeAddress(position);
+		let ownerCount = 0n;
+		let mintCount = 0n;
+		let baseRatePPM: number | undefined;
+		let prevSize: bigint | undefined;
+		let prevPrice: bigint | undefined;
+		let prevMinted: bigint | undefined;
+
+		for (const log of receipt.logs) {
+			if (normalizeAddress(log.address) !== positionNorm) continue;
+			const topic = log.topics[0];
+
+			if (topic === OWNERSHIP_TRANSFERRED_TOPIC) {
+				const t1 = log.topics[1];
+				const t2 = log.topics[2];
+				if (!t1 || !t2) continue;
+				ownerCount++;
+				await context.db
+					.insert(MintingHubV2OwnerTransfersV2)
+					.values({
+						version: 2,
+						position: positionNorm,
+						count: ownerCount,
+						created: event.block.timestamp,
+						previousOwner: normalizeAddress('0x' + t1.slice(26)),
+						newOwner: normalizeAddress('0x' + t2.slice(26)),
+						txHash: event.transaction.hash,
+					})
+					.onConflictDoNothing();
+			} else if (topic === MINTING_UPDATE_TOPIC_V2) {
+				if (baseRatePPM === undefined) {
+					baseRatePPM = Number(
+						await client.readContract({
+							abi: SavingsV2ABI,
+							address: ADDRESS[mainnet.id].savingsV2,
+							functionName: 'currentRatePPM',
+						})
+					);
+				}
+				const [size, logPrice, mintedAmt] = decodeAbiParameters(
+					[{ type: 'uint256' }, { type: 'uint256' }, { type: 'uint256' }],
+					log.data
+				);
+				mintCount++;
+				const annualInterestPPM = baseRatePPM + riskPremiumPPM;
+				const OneYear = 60 * 60 * 24 * 365;
+				const feeTimeframe = Math.floor(Number(expiration) - Number(event.block.timestamp));
+				const feePPM = BigInt(Math.floor((feeTimeframe * annualInterestPPM) / OneYear));
+				const sizeAdjusted = prevSize !== undefined ? size - prevSize : size;
+				const priceAdjusted = prevPrice !== undefined ? logPrice - prevPrice : logPrice;
+				const mintedAdjusted = prevMinted !== undefined ? mintedAmt - prevMinted : mintedAmt;
+				await context.db
+					.insert(MintingHubV2MintingUpdateV2)
+					.values({
+						count: mintCount,
+						txHash: event.transaction.hash,
+						created: event.block.timestamp,
+						position: positionNorm,
+						owner: resolvedOwner,
+						isClone,
+						collateral: normalizeAddress(collateral),
+						collateralName,
+						collateralSymbol,
+						collateralDecimals,
+						size,
+						price: logPrice,
+						minted: mintedAmt,
+						sizeAdjusted,
+						priceAdjusted,
+						mintedAdjusted,
+						annualInterestPPM,
+						basePremiumPPM: baseRatePPM,
+						riskPremiumPPM,
+						reserveContribution,
+						feeTimeframe,
+						feePPM: parseInt(feePPM.toString()),
+						feePaid: mintedAdjusted > 0n ? (feePPM * mintedAdjusted) / 1_000_000n : 0n,
+					})
+					.onConflictDoNothing();
+				prevSize = size;
+				prevPrice = logPrice;
+				prevMinted = mintedAmt;
+			}
+		}
+
+		if (ownerCount > 0n || mintCount > 0n) {
+			await context.db
+				.insert(MintingHubV2Status)
+				.values({
+					position: positionNorm,
+					ownerTransfersCounter: ownerCount,
+					mintingUpdatesCounter: mintCount,
+					challengeStartedCounter: 0n,
+					challengeAvertedBidsCounter: 0n,
+					challengeSucceededBidsCounter: 0n,
+				})
+				.onConflictDoUpdate((current) => ({
+					ownerTransfersCounter: current.ownerTransfersCounter > ownerCount ? current.ownerTransfersCounter : ownerCount,
+					mintingUpdatesCounter: current.mintingUpdatesCounter > mintCount ? current.mintingUpdatesCounter : mintCount,
+				}));
+		}
+	}
 
 	// ------------------------------------------------------------------
 	// COMMON

--- a/src/PositionV1.ts
+++ b/src/PositionV1.ts
@@ -283,15 +283,18 @@ ponder.on('PositionV1:OwnershipTransferred', async ({ event, context }) => {
 			ownerTransfersCounter: current.ownerTransfersCounter + 1n,
 		}));
 
-	await context.db.insert(MintingHubV1OwnerTransfersV1).values({
-		version: 1,
-		position: normalizeAddress(event.log.address),
-		count: status.ownerTransfersCounter,
-		created: event.block.timestamp,
-		previousOwner: normalizeAddress(event.args.previousOwner),
-		newOwner: normalizeAddress(event.args.newOwner),
-		txHash: event.transaction.hash,
-	});
+	await context.db
+		.insert(MintingHubV1OwnerTransfersV1)
+		.values({
+			version: 1,
+			position: normalizeAddress(event.log.address),
+			count: status.ownerTransfersCounter,
+			created: event.block.timestamp,
+			previousOwner: normalizeAddress(event.args.previousOwner),
+			newOwner: normalizeAddress(event.args.newOwner),
+			txHash: event.transaction.hash,
+		})
+		.onConflictDoNothing();
 
 	const position = await context.db.find(MintingHubV1PositionV1, {
 		position: normalizeAddress(event.log.address),

--- a/src/PositionV2.ts
+++ b/src/PositionV2.ts
@@ -244,15 +244,18 @@ ponder.on('PositionV2:OwnershipTransferred', async ({ event, context }) => {
 		context.db.find(MintingHubV2PositionV2, { position: normalizeAddress(event.log.address) }),
 	]);
 
-	await context.db.insert(MintingHubV2OwnerTransfersV2).values({
-		version: 2,
-		position: normalizeAddress(event.log.address),
-		count: status.ownerTransfersCounter,
-		created: event.block.timestamp,
-		previousOwner: normalizeAddress(event.args.previousOwner),
-		newOwner: normalizeAddress(event.args.newOwner),
-		txHash: event.transaction.hash,
-	});
+	await context.db
+		.insert(MintingHubV2OwnerTransfersV2)
+		.values({
+			version: 2,
+			position: normalizeAddress(event.log.address),
+			count: status.ownerTransfersCounter,
+			created: event.block.timestamp,
+			previousOwner: normalizeAddress(event.args.previousOwner),
+			newOwner: normalizeAddress(event.args.newOwner),
+			txHash: event.transaction.hash,
+		})
+		.onConflictDoNothing();
 
 	if (position) {
 		await context.db

--- a/src/PositionV2.ts
+++ b/src/PositionV2.ts
@@ -7,46 +7,10 @@ import {
 	MintingHubV2Status,
 	PositionAggregatesV2,
 } from 'ponder:schema';
-import { Address } from 'viem';
 import { mainnet } from 'viem/chains';
 import { and, eq, gt } from 'ponder';
 import { normalizeAddress } from './utils/format';
-
-const CLONE_HELPER = normalizeAddress(ADDRESS[mainnet.id].cloneHelper);
-// keccak256("OwnershipTransferred(address,address)")
-const OWNERSHIP_TRANSFERRED_TOPIC = '0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0' as const;
-
-/**
- * If a MintingUpdate originates from a CloneHelper tx, the position's owner in the DB is still
- * the CloneHelper (the 0x0→CloneHelper OwnershipTransferred log was already processed, but the
- * CloneHelper→beneficiary transfer log comes later in the same tx).
- * We fetch the receipt and find that second transfer to recover the actual beneficiary.
- */
-async function resolvePositionOwner(
-	owner: Address,
-	positionAddress: Address,
-	txHash: `0x${string}`,
-	client: Context['client']
-): Promise<Address> {
-	if (owner !== CLONE_HELPER) return owner;
-
-	const receipt = await client.getTransactionReceipt({ hash: txHash });
-
-	for (const log of receipt.logs) {
-		if (
-			normalizeAddress(log.address) === positionAddress &&
-			log.topics[0] === OWNERSHIP_TRANSFERRED_TOPIC &&
-			log.topics[1] !== undefined &&
-			log.topics[2] !== undefined &&
-			normalizeAddress(('0x' + log.topics[1].slice(26)) as Address) === CLONE_HELPER
-		) {
-			return normalizeAddress(('0x' + log.topics[2].slice(26)) as Address);
-		}
-	}
-
-	return owner;
-}
-
+import { resolvePositionOwner } from './utils/ownership';
 /*
 Events
 
@@ -144,13 +108,6 @@ ponder.on('PositionV2:MintingUpdate', async ({ event, context }) => {
 			mintingUpdatesCounter: current.mintingUpdatesCounter + 1n,
 		}));
 
-	const resolvedOwner = await resolvePositionOwner(
-		normalizeAddress(position.owner),
-		normalizeAddress(positionAddress),
-		event.transaction.hash,
-		context.client
-	);
-
 	const annualInterestPPM = baseRatePPM + position.riskPremiumPPM;
 	const isClone = normalizeAddress(position.original) !== normalizeAddress(position.position);
 
@@ -158,6 +115,13 @@ ponder.on('PositionV2:MintingUpdate', async ({ event, context }) => {
 	const feeTimeframe = Math.floor(parseInt(position.expiration.toString()) - parseInt(event.block.timestamp.toString()));
 	const feePPM = BigInt(Math.floor((feeTimeframe * annualInterestPPM) / OneYear));
 	const getFeePaid = (amount: bigint): bigint => (feePPM * amount) / 1_000_000n;
+
+	const resolvedOwner = await resolvePositionOwner(
+		normalizeAddress(position.owner),
+		normalizeAddress(positionAddress),
+		event.transaction.hash,
+		client
+	);
 
 	const sharedFields = {
 		txHash: event.transaction.hash,

--- a/src/utils/ownership.ts
+++ b/src/utils/ownership.ts
@@ -8,6 +8,12 @@ export const CLONE_HELPER = normalizeAddress(ADDRESS[mainnet.id].cloneHelper);
 // keccak256("OwnershipTransferred(address,address)")
 export const OWNERSHIP_TRANSFERRED_TOPIC =
 	'0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0' as const;
+// keccak256("MintingUpdate(uint256,uint256,uint256)")
+export const MINTING_UPDATE_TOPIC_V2 =
+	'0x9483a26ad376f30b5199a79e75df3bb05158c4ee32a348f53e83245a5e50c86e' as const;
+// keccak256("MintingUpdate(uint256,uint256,uint256,uint256)")
+export const MINTING_UPDATE_TOPIC_V1 =
+	'0xcb2040b7eb3265a4335698c9ecbe81a5f9857e92aa32e07ce235f44c321a7e35' as const;
 
 /**
  * When a position is opened or minted via CloneHelper, event.args.owner is

--- a/src/utils/ownership.ts
+++ b/src/utils/ownership.ts
@@ -1,0 +1,41 @@
+import { ADDRESS } from '@frankencoin/zchf';
+import { type Context } from 'ponder:registry';
+import { Address } from 'viem';
+import { mainnet } from 'viem/chains';
+import { normalizeAddress } from './format';
+
+export const CLONE_HELPER = normalizeAddress(ADDRESS[mainnet.id].cloneHelper);
+// keccak256("OwnershipTransferred(address,address)")
+export const OWNERSHIP_TRANSFERRED_TOPIC =
+	'0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0' as const;
+
+/**
+ * When a position is opened or minted via CloneHelper, event.args.owner is
+ * still the CloneHelper address at the time the log fires. This reads the
+ * transaction receipt to find the CloneHelper→beneficiary OwnershipTransferred
+ * log and returns the actual owner.
+ */
+export async function resolvePositionOwner(
+	owner: Address,
+	positionAddress: Address,
+	txHash: `0x${string}`,
+	client: Context['client']
+): Promise<Address> {
+	if (owner !== CLONE_HELPER) return owner;
+
+	const receipt = await client.getTransactionReceipt({ hash: txHash });
+
+	for (const log of receipt.logs) {
+		if (
+			normalizeAddress(log.address) === positionAddress &&
+			log.topics[0] === OWNERSHIP_TRANSFERRED_TOPIC &&
+			log.topics[1] !== undefined &&
+			log.topics[2] !== undefined &&
+			normalizeAddress(('0x' + log.topics[1].slice(26)) as Address) === CLONE_HELPER
+		) {
+			return normalizeAddress(('0x' + log.topics[2].slice(26)) as Address);
+		}
+	}
+
+	return owner;
+}


### PR DESCRIPTION
## Problem

Position `0x422050f743582bf753b4D6BF571FA1808A9D70e6` (and others opened via CloneHelper) showed missing data in production with PostgreSQL:

- `mintingHubV2OwnerTransfersV2s` → empty
- `mintingHubV2MintingUpdateV2s` → empty  
- `mintingHubV2PositionV2s.owner` → stuck at CloneHelper address `0x55cd...` instead of the actual beneficiary

Locally (SQLite) all data was correct.

---

## Investigation

### False leads

**Hypothesis 1 — `ponder dev` vs `ponder start`**
Initially suspected the sync engine difference between dev and production mode. Disproved: running `ponder dev` on the production server (PostgreSQL) gave the same wrong output.

**Hypothesis 2 — stale / mid-sync database**
Suspected the production database was still indexing. Disproved: a fresh secondary instance on Railway fully re-indexed and produced the same wrong results.

### Root cause: PostgreSQL drops all same-block events for newly discovered factory addresses

Inspecting the on-chain transaction for this position revealed the full log order in the single creation transaction:

```
[1070]  Position : OwnershipTransferred   (0x0000 → MintingHubV2)        ← pre-discovery
[1072]  MintingHubV2 : PositionOpened                                     ← factory discovery
[1076]  Position : MintingUpdate                                           ← post-discovery, same block
[1077]  Position : OwnershipTransferred   (MintingHubV2 → CloneHelper)    ← post-discovery, same block
[1078]  Position : MintingUpdate                                           ← post-discovery, same block
[1080]  Position : OwnershipTransferred   (CloneHelper → beneficiary)     ← post-discovery, same block
```

**All six events — both before and after `PositionOpened` — were silently dropped in the PostgreSQL-backed instance.**

Reading Ponder's internals (`sync-historical/index.js`, `runtime/filter.js`) revealed the mechanism:

> The `args.childAddresses` map (used by `isAddressMatched` to filter events) is built from the database **before** a sync batch runs. Addresses discovered within the current batch are not yet in the database when that check runs, so every event on the newly discovered address in that batch fails the filter and is dropped.

SQLite / PGlite takes a different code path (`database.driver.dialect === "pglite"` branch in `isolatedController.js`) that processes events sequentially and handles same-block factory events correctly. PostgreSQL does not.

### Why it regressed

This behaviour changed with **Ponder v0.16.0**, which introduced *"Improved backfill indexing performance"* — a significant internal rework of the sync engine batching strategy for factory contracts. Previously (≤ 0.15.x) it worked correctly with PostgreSQL.

### CloneHelper ownership chain

When a position is opened via CloneHelper the full ownership transfer sequence is:

```
Constructor  →  OwnershipTransferred(0x0, MintingHubV2)
MintingHubV2 →  OwnershipTransferred(MintingHubV2, CloneHelper)
CloneHelper  →  OwnershipTransferred(CloneHelper, beneficiary)
MintingHubV2 →  PositionOpened(owner = CloneHelper)   ← logged after all transfers
```

Because all transfers happen before `PositionOpened`, the existing `resolvePositionOwner` helper (receipt scan to find CloneHelper → beneficiary) was not enough on its own — none of the transfers were being indexed at all.

---

## Alternative fix tested: Railway volume + PGlite

Removing `DATABASE_URL` and mounting a persistent Railway volume at `/app/.ponder` switches Ponder to PGlite, which takes the correct code path and indexes all same-block events natively. This was **tested and confirmed working** — all 3 OwnerTransfers, correct owner, 2 MintingUpdates appeared correctly after a fresh re-index.

Decided **against this approach** for the primary instance because:
- PostgreSQL has 2.5 years of accumulated cached RPC data, making re-indexes significantly faster
- PGlite is single-writer; no concern for an indexer, but the operational familiarity with PostgreSQL is preferred

The PGlite path remains a valid fallback and the code is compatible with both backends.

---

## Solution

Gate a receipt scan on `process.env.DATABASE_URL` (i.e. PostgreSQL only) inside both `MintingHubV1:PositionOpened` and `MintingHubV2:PositionOpened`. After the position row is created, scan the full transaction receipt and backfill every event on the position address that Ponder would have processed but dropped.

### What is backfilled

| Event | Handler | Records created |
|---|---|---|
| `OwnershipTransferred` | V1 + V2 | `MintingHubV1/V2OwnerTransfersV1/V2` |
| `MintingUpdate` | V1 + V2 | `MintingHubV1/V2MintingUpdateV1/V2` |

All inserts use `onConflictDoNothing` — safe for PGlite runs where Ponder processes the events natively, and idempotent on retries.

Status counters (`ownerTransfersCounter`, `mintingUpdatesCounter`) are upserted atomically with a `max(current, backfilled)` strategy so future events processed by the normal handlers continue at the correct sequential count.

### Owner resolution

`resolvePositionOwner` is called in `PositionOpened` before the position row is created, so the position is stored with the correct final owner from the start — not the intermediate CloneHelper address.

The same resolution is applied in `PositionV2:MintingUpdate` so minting records are also stamped with the correct beneficiary when the position's stored owner is still CloneHelper at event time.

### V1 vs V2 differences

- V1 `MintingUpdate` has 4 params `(uint256, uint256, uint256, uint256)` vs V2's 3
- V1 fee timeframe uses `Math.max(OneMonth, secToExp)`; V2 uses `secToExp` directly
- V2 fetches `baseRatePPM` from SavingsV2 lazily (only when MintingUpdate logs exist); V1 uses `annualInterestPPM` already read in `PositionOpened`

---

## Verified production output (PostgreSQL, secondary instance)

```json
{
  "mintingHubV2PositionV2s":      { "owner": "0x92918c4608df0e200f0a5547241678072c172b76" },
  "mintingHubV2OwnerTransfersV2s": { "items": [{ "count": "1" }, { "count": "2" }, { "count": "3" }] },
  "mintingHubV2Statuss":           { "ownerTransfersCounter": "3", "mintingUpdatesCounter": "2" },
  "mintingHubV2MintingUpdateV2s":  { "items": [{ "count": "1" }, { "count": "2" }] }
}
```

Matches local (SQLite) output exactly.

---

## Follow-up

This is a Ponder bug introduced in v0.16.0 — PostgreSQL and PGlite should behave identically for factory contracts. Worth filing upstream at [ponder-sh/ponder](https://github.com/ponder-sh/ponder/issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)