### PR TITLE
feat: index CCIPAdmin contract with proposals, chain state and tx hashes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ yarn-error.log*
 # Ponder
 /generated/
 /.ponder*
+
+# Backups
+/scripts/*.dump

--- a/ponder.config.ts
+++ b/ponder.config.ts
@@ -34,7 +34,7 @@ export const config = {
 		startMintingHubV2: 21280757,
 		startTransferReference: 22678761,
 		startSavingsReferal: 22536327,
-		startCCIP: 22623046,
+		startCCIP: 22623055,
 		startUniswapPoolV3: 19122801,
 	},
 

--- a/ponder.config.ts
+++ b/ponder.config.ts
@@ -3,6 +3,7 @@ import { arbitrum, avalanche, base, gnosis, mainnet, optimism, polygon, sonic } 
 import { createPublicClient, erc20Abi, http } from 'viem';
 import {
 	ADDRESS,
+	CCIPAdminABI,
 	EquityABI,
 	FrankencoinABI,
 	MintingHubV1ABI,
@@ -389,6 +390,44 @@ export default createConfig({
 		},
 
 		// ### CROSS CHAIN SUPPORT ###
+
+		CCIPAdmin: {
+			abi: CCIPAdminABI,
+			chain: {
+				[mainnet.name]: {
+					address: addr[mainnet.id].ccipAdmin,
+					startBlock: config[mainnet.id].startCCIP,
+				},
+				[polygon.name]: {
+					address: addr[polygon.id].ccipAdmin,
+					startBlock: config[polygon.id].startBridgedFrankencoin,
+				},
+				[arbitrum.name]: {
+					address: addr[arbitrum.id].ccipAdmin,
+					startBlock: config[arbitrum.id].startBridgedFrankencoin,
+				},
+				[optimism.name]: {
+					address: addr[optimism.id].ccipAdmin,
+					startBlock: config[optimism.id].startBridgedFrankencoin,
+				},
+				[base.name]: {
+					address: addr[base.id].ccipAdmin,
+					startBlock: config[base.id].startBridgedFrankencoin,
+				},
+				[avalanche.name]: {
+					address: addr[avalanche.id].ccipAdmin,
+					startBlock: config[avalanche.id].startBridgedFrankencoin,
+				},
+				[gnosis.name]: {
+					address: addr[gnosis.id].ccipAdmin,
+					startBlock: config[gnosis.id].startBridgedFrankencoin,
+				},
+				[sonic.name]: {
+					address: addr[sonic.id].ccipAdmin,
+					startBlock: config[sonic.id].startBridgedFrankencoin,
+				},
+			},
+		},
 
 		CCIPBridgedAccounting: {
 			abi: BridgeAccountingABI,

--- a/ponder.config.ts
+++ b/ponder.config.ts
@@ -28,7 +28,7 @@ export const config = {
 		rpc: `https://eth-mainnet.g.alchemy.com/v2/${process.env.ALCHEMY_RPC_KEY}`,
 		maxRequestsPerSecond: parseInt(process.env.MAX_REQUESTS_PER_SECOND || '10'),
 		pollingInterval: parseInt(process.env.POLLING_INTERVAL_MS || '30000'),
-		ethGetLogsBlockRange: 500, // ~12s blocks
+		ethGetLogsBlockRange: 5000, // ~12s blocks
 		startFrankencoin: 18451518,
 		startMintingHubV1: 18451536,
 		startMintingHubV2: 21280757,
@@ -43,7 +43,7 @@ export const config = {
 		rpc: `https://polygon-mainnet.g.alchemy.com/v2/${process.env.ALCHEMY_RPC_KEY}`,
 		maxRequestsPerSecond: parseInt(process.env.MAX_REQUESTS_PER_SECOND || '10'),
 		pollingInterval: parseInt(process.env.POLLING_INTERVAL_MS || '30000'),
-		ethGetLogsBlockRange: 2000, // ~2s blocks
+		ethGetLogsBlockRange: 5000, // ~2s blocks
 		startBridgedFrankencoin: 72384538,
 		startSavingsReferal: 72993144,
 	},
@@ -59,7 +59,7 @@ export const config = {
 		rpc: `https://opt-mainnet.g.alchemy.com/v2/${process.env.ALCHEMY_RPC_KEY}`,
 		maxRequestsPerSecond: parseInt(process.env.MAX_REQUESTS_PER_SECOND || '10'),
 		pollingInterval: parseInt(process.env.POLLING_INTERVAL_MS || '30000'),
-		ethGetLogsBlockRange: 2000, // ~2s blocks
+		ethGetLogsBlockRange: 5000, // ~2s blocks
 		startBridgedFrankencoin: 136678320,
 		startSavingsReferal: 137404676,
 	},
@@ -67,7 +67,7 @@ export const config = {
 		rpc: `https://base-mainnet.g.alchemy.com/v2/${process.env.ALCHEMY_RPC_KEY}`,
 		maxRequestsPerSecond: parseInt(process.env.MAX_REQUESTS_PER_SECOND || '10'),
 		pollingInterval: parseInt(process.env.POLLING_INTERVAL_MS || '30000'),
-		ethGetLogsBlockRange: 2000, // ~2s blocks
+		ethGetLogsBlockRange: 5000, // ~2s blocks
 		startBridgedFrankencoin: 31080190,
 		startSavingsReferal: 31809565,
 	},
@@ -75,7 +75,7 @@ export const config = {
 		rpc: `https://avax-mainnet.g.alchemy.com/v2/${process.env.ALCHEMY_RPC_KEY}`,
 		maxRequestsPerSecond: parseInt(process.env.MAX_REQUESTS_PER_SECOND || '10'),
 		pollingInterval: parseInt(process.env.POLLING_INTERVAL_MS || '30000'),
-		ethGetLogsBlockRange: 2000, // ~2s blocks
+		ethGetLogsBlockRange: 5000, // ~2s blocks
 		startBridgedFrankencoin: 63337938,
 		startSavingsReferal: 64919925,
 	},
@@ -83,7 +83,7 @@ export const config = {
 		rpc: `https://gnosis-mainnet.g.alchemy.com/v2/${process.env.ALCHEMY_RPC_KEY}`,
 		maxRequestsPerSecond: parseInt(process.env.MAX_REQUESTS_PER_SECOND || '10'),
 		pollingInterval: parseInt(process.env.POLLING_INTERVAL_MS || '30000'),
-		ethGetLogsBlockRange: 500, // ~5s blocks
+		ethGetLogsBlockRange: 5000, // ~5s blocks
 		startBridgedFrankencoin: 40394536,
 		startSavingsReferal: 40678291,
 	},

--- a/ponder.schema.ts
+++ b/ponder.schema.ts
@@ -1,4 +1,5 @@
 export * from './schema/BridgedAccounting';
+export * from './schema/CCIPAdmin';
 export * from './schema/Common';
 export * from './schema/Equity';
 export * from './schema/ERC20';

--- a/schema/CCIPAdmin.ts
+++ b/schema/CCIPAdmin.ts
@@ -11,8 +11,11 @@ export const CCIPAdminProposal = onchainTable(
 		status: t.text().notNull(), // 'Pending' | 'Denied' | 'Enacted'
 		details: t.text(),
 		created: t.bigint().notNull(),
+		txHash: t.hex().notNull(),
 		deniedAt: t.bigint(),
+		deniedTxHash: t.hex(),
 		enactedAt: t.bigint(),
+		enactedTxHash: t.hex(),
 	}),
 	(table) => ({
 		pk: primaryKey({ columns: [table.chainId, table.hash] }),
@@ -33,6 +36,7 @@ export const CCIPAdminChain = onchainTable(
 		inboundCapacity: t.bigint().notNull(),
 		inboundRate: t.bigint().notNull(),
 		rateLimitUpdatedAt: t.bigint(),
+		rateLimitTxHash: t.hex(),
 	}),
 	(table) => ({
 		pk: primaryKey({ columns: [table.chainId, table.remoteChainSelector] }),

--- a/schema/CCIPAdmin.ts
+++ b/schema/CCIPAdmin.ts
@@ -11,6 +11,8 @@ export const CCIPAdminProposal = onchainTable(
 		status: t.text().notNull(), // 'Pending' | 'Denied' | 'Enacted'
 		details: t.text(),
 		created: t.bigint().notNull(),
+		deniedAt: t.bigint(),
+		enactedAt: t.bigint(),
 	}),
 	(table) => ({
 		pk: primaryKey({ columns: [table.chainId, table.hash] }),
@@ -30,6 +32,7 @@ export const CCIPAdminChain = onchainTable(
 		inboundEnabled: t.boolean().notNull(),
 		inboundCapacity: t.bigint().notNull(),
 		inboundRate: t.bigint().notNull(),
+		rateLimitUpdatedAt: t.bigint(),
 	}),
 	(table) => ({
 		pk: primaryKey({ columns: [table.chainId, table.remoteChainSelector] }),

--- a/schema/CCIPAdmin.ts
+++ b/schema/CCIPAdmin.ts
@@ -1,0 +1,37 @@
+import { onchainTable, primaryKey } from 'ponder';
+
+export const CCIPAdminProposal = onchainTable(
+	'CCIPAdminProposal',
+	(t) => ({
+		chainId: t.integer().notNull(),
+		hash: t.hex().notNull(),
+		proposer: t.hex(),
+		type: t.text(), // 'AddChain' | 'RemoveChain' | 'RemotePoolUpdate' | 'AdminTransfer'
+		deadline: t.bigint().notNull(),
+		status: t.text().notNull(), // 'Pending' | 'Denied' | 'Enacted'
+		details: t.text(),
+		created: t.bigint().notNull(),
+	}),
+	(table) => ({
+		pk: primaryKey({ columns: [table.chainId, table.hash] }),
+	})
+);
+
+export const CCIPAdminChain = onchainTable(
+	'CCIPAdminChain',
+	(t) => ({
+		chainId: t.integer().notNull(),
+		remoteChainSelector: t.bigint().notNull(),
+		active: t.boolean().notNull(),
+		remoteTokenAddress: t.text(),
+		outboundEnabled: t.boolean().notNull(),
+		outboundCapacity: t.bigint().notNull(),
+		outboundRate: t.bigint().notNull(),
+		inboundEnabled: t.boolean().notNull(),
+		inboundCapacity: t.bigint().notNull(),
+		inboundRate: t.bigint().notNull(),
+	}),
+	(table) => ({
+		pk: primaryKey({ columns: [table.chainId, table.remoteChainSelector] }),
+	})
+);

--- a/scripts/.env.example
+++ b/scripts/.env.example
@@ -1,0 +1,1 @@
+RAILWAY_DB=postgresql://user:pw@domain:port/database

--- a/scripts/db-dump.sh
+++ b/scripts/db-dump.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+DB_URL="${RAILWAY_DB:-$1}"
+
+if [ -z "$DB_URL" ]; then
+  echo "Usage: RAILWAY_DB=postgresql://... ./scripts/db-dump.sh"
+  echo "   or: ./scripts/db-dump.sh postgresql://..."
+  exit 1
+fi
+
+TIMESTAMP=$(date +"%Y-%m-%d_%H-%M-%S")
+OUTPUT="scripts/backup_${TIMESTAMP}.dump"
+
+echo "Dumping database to ${OUTPUT}..."
+docker run --rm \
+  -v "$(pwd):/backup" \
+  postgres:18 \
+  pg_dump "$DB_URL" -Fc -f "/backup/backup_${TIMESTAMP}.dump"
+echo "Done. File: ${OUTPUT} ($(du -sh "$OUTPUT" | cut -f1))"

--- a/src/CCIPAdmin.ts
+++ b/src/CCIPAdmin.ts
@@ -56,12 +56,14 @@ ponder.on('CCIPAdmin:AdminTransferProposed', async ({ event, context }) => {
 ponder.on('CCIPAdmin:ProposalDenied', async ({ event, context }) => {
 	await context.db.update(CCIPAdminProposal, { chainId: context.chain.id, hash: event.args.hash }).set({
 		status: 'Denied',
+		deniedAt: event.block.timestamp,
 	});
 });
 
 ponder.on('CCIPAdmin:ProposalEnacted', async ({ event, context }) => {
 	await context.db.update(CCIPAdminProposal, { chainId: context.chain.id, hash: event.args.hash }).set({
 		status: 'Enacted',
+		enactedAt: event.block.timestamp,
 	});
 });
 
@@ -113,5 +115,6 @@ ponder.on('CCIPAdmin:RateLimit', async ({ event, context }) => {
 			inboundEnabled: inboundConfigs.isEnabled,
 			inboundCapacity: inboundConfigs.capacity,
 			inboundRate: inboundConfigs.rate,
+			rateLimitUpdatedAt: event.block.timestamp,
 		});
 });

--- a/src/CCIPAdmin.ts
+++ b/src/CCIPAdmin.ts
@@ -14,6 +14,7 @@ ponder.on('CCIPAdmin:ProposalMade', async ({ event, context }) => {
 		deadline: BigInt(deadline),
 		status: 'Pending',
 		created: event.block.timestamp,
+		txHash: event.transaction.hash,
 	});
 });
 
@@ -57,6 +58,7 @@ ponder.on('CCIPAdmin:ProposalDenied', async ({ event, context }) => {
 	await context.db.update(CCIPAdminProposal, { chainId: context.chain.id, hash: event.args.hash }).set({
 		status: 'Denied',
 		deniedAt: event.block.timestamp,
+		deniedTxHash: event.transaction.hash,
 	});
 });
 
@@ -64,6 +66,7 @@ ponder.on('CCIPAdmin:ProposalEnacted', async ({ event, context }) => {
 	await context.db.update(CCIPAdminProposal, { chainId: context.chain.id, hash: event.args.hash }).set({
 		status: 'Enacted',
 		enactedAt: event.block.timestamp,
+		enactedTxHash: event.transaction.hash,
 	});
 });
 
@@ -122,6 +125,7 @@ ponder.on('CCIPAdmin:RateLimit', async ({ event, context }) => {
 			inboundCapacity: inboundConfigs.capacity,
 			inboundRate: inboundConfigs.rate,
 			rateLimitUpdatedAt: event.block.timestamp,
+			rateLimitTxHash: event.transaction.hash,
 		})
 		.onConflictDoUpdate(() => ({
 			outboundEnabled: outboundConfig.isEnabled,
@@ -131,5 +135,6 @@ ponder.on('CCIPAdmin:RateLimit', async ({ event, context }) => {
 			inboundCapacity: inboundConfigs.capacity,
 			inboundRate: inboundConfigs.rate,
 			rateLimitUpdatedAt: event.block.timestamp,
+			rateLimitTxHash: event.transaction.hash,
 		}));
 });

--- a/src/CCIPAdmin.ts
+++ b/src/CCIPAdmin.ts
@@ -1,0 +1,117 @@
+import { ponder } from 'ponder:registry';
+import { CCIPAdminProposal, CCIPAdminChain } from 'ponder:schema';
+
+const toJson = (obj: unknown): string =>
+	JSON.stringify(obj, (_, v) => (typeof v === 'bigint' ? v.toString() : v));
+
+// ── Proposal lifecycle ────────────────────────────────────────────────────────
+
+ponder.on('CCIPAdmin:ProposalMade', async ({ event, context }) => {
+	const { hash, deadline } = event.args;
+	await context.db.insert(CCIPAdminProposal).values({
+		chainId: context.chain.id,
+		hash,
+		deadline: BigInt(deadline),
+		status: 'Pending',
+		created: event.block.timestamp,
+	});
+});
+
+ponder.on('CCIPAdmin:AddChainProposed', async ({ event, context }) => {
+	const { hash, proposer, update } = event.args;
+	await context.db.update(CCIPAdminProposal, { chainId: context.chain.id, hash }).set({
+		proposer,
+		type: 'AddChain',
+		details: toJson(update),
+	});
+});
+
+ponder.on('CCIPAdmin:RemoveChainProposed', async ({ event, context }) => {
+	const { hash, proposer, chain } = event.args;
+	await context.db.update(CCIPAdminProposal, { chainId: context.chain.id, hash }).set({
+		proposer,
+		type: 'RemoveChain',
+		details: toJson({ chain }),
+	});
+});
+
+ponder.on('CCIPAdmin:RemotePoolUpdateProposed', async ({ event, context }) => {
+	const { hash, proposer, update } = event.args;
+	await context.db.update(CCIPAdminProposal, { chainId: context.chain.id, hash }).set({
+		proposer,
+		type: 'RemotePoolUpdate',
+		details: toJson(update),
+	});
+});
+
+ponder.on('CCIPAdmin:AdminTransferProposed', async ({ event, context }) => {
+	const { hash, proposer, newAdmin } = event.args;
+	await context.db.update(CCIPAdminProposal, { chainId: context.chain.id, hash }).set({
+		proposer,
+		type: 'AdminTransfer',
+		details: toJson({ newAdmin }),
+	});
+});
+
+ponder.on('CCIPAdmin:ProposalDenied', async ({ event, context }) => {
+	await context.db.update(CCIPAdminProposal, { chainId: context.chain.id, hash: event.args.hash }).set({
+		status: 'Denied',
+	});
+});
+
+ponder.on('CCIPAdmin:ProposalEnacted', async ({ event, context }) => {
+	await context.db.update(CCIPAdminProposal, { chainId: context.chain.id, hash: event.args.hash }).set({
+		status: 'Enacted',
+	});
+});
+
+// ── Chain state ───────────────────────────────────────────────────────────────
+
+ponder.on('CCIPAdmin:ChainAdded', async ({ event, context }) => {
+	const { config } = event.args;
+	await context.db
+		.insert(CCIPAdminChain)
+		.values({
+			chainId: context.chain.id,
+			remoteChainSelector: BigInt(config.remoteChainSelector),
+			active: true,
+			remoteTokenAddress: config.remoteTokenAddress,
+			outboundEnabled: config.outboundRateLimiterConfig.isEnabled,
+			outboundCapacity: config.outboundRateLimiterConfig.capacity,
+			outboundRate: config.outboundRateLimiterConfig.rate,
+			inboundEnabled: config.inboundRateLimiterConfig.isEnabled,
+			inboundCapacity: config.inboundRateLimiterConfig.capacity,
+			inboundRate: config.inboundRateLimiterConfig.rate,
+		})
+		.onConflictDoUpdate(() => ({
+			active: true,
+			remoteTokenAddress: config.remoteTokenAddress,
+			outboundEnabled: config.outboundRateLimiterConfig.isEnabled,
+			outboundCapacity: config.outboundRateLimiterConfig.capacity,
+			outboundRate: config.outboundRateLimiterConfig.rate,
+			inboundEnabled: config.inboundRateLimiterConfig.isEnabled,
+			inboundCapacity: config.inboundRateLimiterConfig.capacity,
+			inboundRate: config.inboundRateLimiterConfig.rate,
+		}));
+});
+
+ponder.on('CCIPAdmin:ChainRemoved', async ({ event, context }) => {
+	await context.db
+		.update(CCIPAdminChain, { chainId: context.chain.id, remoteChainSelector: BigInt(event.args.id) })
+		.set({ active: false });
+});
+
+// Note: RateLimit ABI has inboundConfigs as 2nd param and outboundConfig as 3rd
+ponder.on('CCIPAdmin:RateLimit', async ({ event, context }) => {
+	const { remoteChain, inboundConfigs, outboundConfig } = event.args;
+	await context.db
+		.update(CCIPAdminChain, { chainId: context.chain.id, remoteChainSelector: BigInt(remoteChain) })
+		.set({
+			outboundEnabled: outboundConfig.isEnabled,
+			outboundCapacity: outboundConfig.capacity,
+			outboundRate: outboundConfig.rate,
+			inboundEnabled: inboundConfigs.isEnabled,
+			inboundCapacity: inboundConfigs.capacity,
+			inboundRate: inboundConfigs.rate,
+		});
+});

--- a/src/CCIPAdmin.ts
+++ b/src/CCIPAdmin.ts
@@ -98,6 +98,8 @@ ponder.on('CCIPAdmin:ChainAdded', async ({ event, context }) => {
 });
 
 ponder.on('CCIPAdmin:ChainRemoved', async ({ event, context }) => {
+	const existing = await context.db.find(CCIPAdminChain, { chainId: context.chain.id, remoteChainSelector: BigInt(event.args.id) });
+	if (!existing) return;
 	await context.db
 		.update(CCIPAdminChain, { chainId: context.chain.id, remoteChainSelector: BigInt(event.args.id) })
 		.set({ active: false });
@@ -107,8 +109,12 @@ ponder.on('CCIPAdmin:ChainRemoved', async ({ event, context }) => {
 ponder.on('CCIPAdmin:RateLimit', async ({ event, context }) => {
 	const { remoteChain, inboundConfigs, outboundConfig } = event.args;
 	await context.db
-		.update(CCIPAdminChain, { chainId: context.chain.id, remoteChainSelector: BigInt(remoteChain) })
-		.set({
+		.insert(CCIPAdminChain)
+		.values({
+			chainId: context.chain.id,
+			remoteChainSelector: BigInt(remoteChain),
+			active: true,
+			remoteTokenAddress: null,
 			outboundEnabled: outboundConfig.isEnabled,
 			outboundCapacity: outboundConfig.capacity,
 			outboundRate: outboundConfig.rate,
@@ -116,5 +122,14 @@ ponder.on('CCIPAdmin:RateLimit', async ({ event, context }) => {
 			inboundCapacity: inboundConfigs.capacity,
 			inboundRate: inboundConfigs.rate,
 			rateLimitUpdatedAt: event.block.timestamp,
-		});
+		})
+		.onConflictDoUpdate(() => ({
+			outboundEnabled: outboundConfig.isEnabled,
+			outboundCapacity: outboundConfig.capacity,
+			outboundRate: outboundConfig.rate,
+			inboundEnabled: inboundConfigs.isEnabled,
+			inboundCapacity: inboundConfigs.capacity,
+			inboundRate: inboundConfigs.rate,
+			rateLimitUpdatedAt: event.block.timestamp,
+		}));
 });


### PR DESCRIPTION
## Summary
- Adds full indexing of `CCIPAdmin` contract across all 8 chains (mainnet + 7 L2s)
- New `CCIPAdminProposal` table tracks the full proposal lifecycle (Pending → Denied/Enacted) with `txHash`, `deniedTxHash`, `enactedTxHash` and timestamps
- New `CCIPAdminChain` table tracks current remote chain configuration and rate limits, including `rateLimitTxHash`
- Handlers are upsert-safe: `RateLimit` creates a row if `ChainAdded` predates the start block; `ChainRemoved` skips silently if no row exists
- Increases `ethGetLogsBlockRange` for all chains and adds backup indexer support

## Test plan
- [x] Verify `cCIPAdminProposals` query returns data from mainnet and L2s
- [x] Verify `cCIPAdminChains` query reflects current rate limit state per chain
- [x] Confirm no `RecordNotFoundError` on `RateLimit` events for pre-indexed chains
- [x] Check that `deniedTxHash` / `enactedTxHash` are populated on resolved proposals

🤖 Generated with [Claude Code](https://claude.com/claude-code)